### PR TITLE
Major CI overhaul

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -1,0 +1,12 @@
+name: Build a Docker image
+
+inputs:
+  tag:
+    description: Tag for the built Docker image
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build the image itself
+      run: docker build -t ${{ inputs.tag }} -f docker/Dockerfile .

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,30 @@
+name: Push
+
+on:
+  push:
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  docker-build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Run docker-build local action
+        uses: ./.github/actions/docker-build
+        with:
+          tag: witnet/price-feeds-poller
+
+  docker-run:
+    name: Try some commands in Docker image
+    runs-on: ubuntu-latest
+    needs: ["docker-build"]
+    steps:
+      - name: Try to run main command
+        run: docker run witnet/price-feeds-poller -h
+      - name: Try to run witnet-toolkit
+        run: docker run --entrypoint npx witnet/price-feeds-poller witnet-toolkit --version
+

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,27 @@
+name: Release on Docker Hub upon pushing a tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  preparations:
+    name: Preparations
+    runs-on: ubuntu-latest
+    uses: ./.github/workflows/push
+
+  docker-publish:
+    name: Publish Docker image as tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag image
+        run: docker tag witnet/price-feeds-poller:latest witnet/price-feeds-poller:${{github.ref_name}}
+      - name: Log into Docker Hub
+        uses: docker/login-action@v2.2.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push image to Docker Hub
+        run: docker push witnet/price-feeds-poller:${{github.ref_name}}
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# price_feed_poller
+# Witnet Price Feeds Poller
 
+## Basic setup
+
+```console
 virtualenv -p python3 .
 source bin/activate
 pip install -r requirements.txt
 python price_feeds_poller.py
+```
+
+## Docker image building
+
+### Automated builds
+
+This repository automatically builds and publishes images on Docker Hub upon pushing a new git tag.
+
+### Manual builds
+
+Building the Docker image manually is also possible:
+
+```console
+docker build -t witnet/price-feeds-poller -f docker/Dockerfile .
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,24 @@
-FROM nikolaik/python-nodejs:python3.9-nodejs14
+FROM ubuntu:jammy
 
-# Update apt, first
-RUN ["apt", "update"]
+# Update APT and install system dependencies
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -yqq --no-install-recommends \
+        build-essential \
+        npm \
+        pip \
+        python3-dev
 
 # Copy context and cd into it
 COPY / /home/pn/app
 WORKDIR /home/pn/app
 
-# Install dependencies
-RUN ["pip", "install", "-r", "requirements.txt"]
-RUN ["npm", "install"]
-RUN ["npx", "witnet-toolkit", "update"]
+# Install Python and NodeJS dependencies
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
+RUN --mount=type=cache,target=/node_modules \
+    npm install
+RUN npx witnet-toolkit update
 
 # Set the entrypoint
-ENTRYPOINT ["python", "price_feeds_poller.py"]
+ENTRYPOINT ["python3", "price_feeds_poller.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==19.3.0
 base58==2.0.0
 certifi==2019.11.28
 chardet==3.0.4
-cytoolz==0.10.1
+cytoolz==0.12.2
 eth-hash==0.2.0
 eth-typing==2.2.1
 idna==2.8


### PR DESCRIPTION
After spending several days trying to get witnet-rust to compile statically against GLIBC, I concluded that it is still not possible at this stage — and probably not even a good idea.

This PR works around the compatibility issue of this repo with witnet-rust >= 1.6.4 by replacing the Dockerfile altogether by one that is based on Ubuntu 22.04 LTS, and installs only the strictly needed dependencies.

This also adds Github Actions for verifying that all of these steps run correctly after any push:
- The Docker image builds
- The main Python script runs
- The witnet-toolkit runs

Additionally, there's another Actions workflow for pushing to Docker Hub. Simply create and push a new git tag, and the image will be built and published to Docker Hub on the fly.

Enjoy!